### PR TITLE
Generate Angular DI annnotations

### DIFF
--- a/dist/angular-insight.js
+++ b/dist/angular-insight.js
@@ -2,8 +2,8 @@
 (function (global){
 var _ = (typeof window !== "undefined" ? window._ : typeof global !== "undefined" ? global._ : null);
 
-insightDirective.$inject = ['$q', 'filterFilter', 'orderByFilter'];
-function insightDirective($q, filterFilter, orderByFilter){
+// @ngInject
+module.exports = function insightDirective ($q, filterFilter, orderByFilter) {
 	return {
 		restrict: 'A',
 		require: '?ngModel',
@@ -156,8 +156,8 @@ function insightDirective($q, filterFilter, orderByFilter){
 		}
 	}
 };
+module.exports.$inject = ["$q", "filterFilter", "orderByFilter"];
 
-module.exports = insightDirective;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 },{}],2:[function(require,module,exports){

--- a/insightDirective.js
+++ b/insightDirective.js
@@ -1,7 +1,7 @@
 var _ = require('underscore');
 
-insightDirective.$inject = ['$q', 'filterFilter', 'orderByFilter'];
-function insightDirective($q, filterFilter, orderByFilter){
+// @ngInject
+module.exports = function insightDirective ($q, filterFilter, orderByFilter) {
 	return {
 		restrict: 'A',
 		require: '?ngModel',
@@ -155,4 +155,3 @@ function insightDirective($q, filterFilter, orderByFilter){
 	}
 };
 
-module.exports = insightDirective;

--- a/package.json
+++ b/package.json
@@ -11,11 +11,13 @@
     "beefy": "^2.1.3",
     "brfs": "^1.4.0",
     "browserify": "^9.0.3",
+    "browserify-ngannotate": "^0.7.1",
     "browserify-shim": "^3.8.3",
     "watchify": "^2.4.0"
   },
   "browserify": {
     "transform": [
+      "browserify-ngannotate",
       "browserify-shim",
       "brfs"
     ]


### PR DESCRIPTION
Adds the [ng-annotate browserify transform](https://github.com/omsmith/browserify-ngannotate). If an `@ngInject` comment is prepended to the `module.exports` assignment, the `$inject` property is automatically added:

``` js
// @ngInject
module.exports = function ($scope) {}

=>

//@ ngInject
module.exports = function ($scope) {}
module.exports.$inject = ["$scope"];
```
