### PR TITLE
Remove preinstall npm script

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,12 @@
 
 A simple Angular directive to select things
 
-## Build Prerequsites
+## Build Angular Insight
 
-* Install browserify globally. Optionally install watchify and beefy globally.
-  Install all three with `npm install -g browserify watchify beefy` or
-  `npm run preinstall`.
 * Clone this repository
 * Run `npm install`
 * Run `bower install`
+* Run `npm run bundle` to build using browserify
 
 ## Launch the example app
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "preinstall": "npm install -g browserify watchify beefy",
     "bundle": "browserify insightModule.js -o dist/angular-insight.js",
     "bundle-example": "browserify examples/index.js -o examples/bundle.js",
     "watch-example": "watchify examples/index.js -o examples/bundle.js",


### PR DESCRIPTION
Preinstall script ran for every npm install. This was unintentional, as npm automatically runs pre and post hooks based on script name, and resulted in developer setup frustrations.

Updates documentation to remove global installation prerequisites in favor of npm scripts, which can reference local dependencies.
